### PR TITLE
Use Common Form tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-# build output
-*.docx
-*.pdf
+node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:dubnium-jessie
+
+# Accept EULA for Microsoft fonts
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+RUN echo deb http://httpredir.debian.org/debian jessie main contrib non-free > /etc/apt/sources.list
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y make unoconv ttf-mscorefonts-installer
+RUN fc-cache -f
+
+WORKDIR /workdir
+
+COPY package.json /workdir/package.json
+COPY package-lock.json /workdir/package-lock.json
+RUN npm install
+
+COPY . /workdir
+
+CMD /usr/bin/unoconv --listener && make

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,9 @@ critique: $(FORMS) | $(CRITIQUE) $(JSON)
 
 clean:
 	rm -rf $(BUILD)
+
+docker:
+	docker build -t open-use-of-data-agreement .
+	docker run --name open-use-of-data-agreement open-use-of-data-agreement
+	docker cp open-use-of-data-agreement:/workdir/$(BUILD) .
+	docker rm open-use-of-data-agreement

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+CFCM=node_modules/.bin/commonform-commonmark
+CFDOCX=node_modules/.bin/commonform-docx
+CFHTML=node_modules/.bin/commonform-html
+CRITIQUE=node_modules/.bin/commonform-critique
+JSON=node_modules/.bin/json
+LINT=node_modules/.bin/commonform-lint
+MUSTACHE=node_modules/.bin/mustache
+TOOLS=$(CFCM) $(CFDOCX) $(CFHTML) $(CRITIQUE) $(JSON) $(LINT) $(MUSTACHE)
+
+BUILD=build
+SOURCES=$(filter-out README.md,$(wildcard *.md))
+FORMS=$(addsuffix .form.json,$(addprefix $(BUILD)/,$(SOURCES:.md=)))
+TITLE=Open Use of Data Agreement
+
+all: docx pdf html
+
+docx: $(addprefix $(BUILD)/,$(SOURCES:.md=.docx))
+pdf: $(addprefix $(BUILD)/,$(SOURCES:.md=.pdf))
+html: $(addprefix $(BUILD)/,$(SOURCES:.md=.html))
+
+$(BUILD)/%.docx: $(BUILD)/%.form.json styles.json | $(CFDOCX) $(BUILD)
+	$(CFDOCX) --title "$(TITLE)" --edition "$(EDITION)" --number decimal --indent-margins --left-align-title --styles styles.json $< > $@
+
+$(BUILD)/%.md: $(BUILD)/%.form.json | $(CFCM) $(BUILD)
+	$(CFCM) stringify --title "$(TITLE)" --edition "$(EDITION)" < $< > $@
+
+$(BUILD)/%.html: $(BUILD)/%.form.json | $(CFHTML) $(BUILD)
+	$(CFHTML) --html5 --lists --title "$(TITLE)" --edition "$(EDITION)" < $< > $@
+
+$(BUILD)/%.form.json: %.md | $(JSON) $(CFCM) $(BUILD)
+	$(CFCM) parse --only form < $< | json content.0.form > $@
+
+%.pdf: %.docx
+	unoconv $<
+
+$(BUILD):
+	mkdir -p $@
+
+$(TOOLS):
+	npm install
+
+.PHONY: clean docker lint critique
+
+lint: $(FORMS) | $(LINT) $(JSON)
+	@for form in $(FORMS); do \
+		echo ; \
+		echo $$form; \
+		cat $$form | $(LINT) | $(JSON) -a message | sort -u; \
+	done; \
+
+critique: $(FORMS) | $(CRITIQUE) $(JSON)
+	@for form in $(FORMS); do \
+		echo ; \
+		echo $$form ; \
+		cat $$form | $(CRITIQUE) | $(JSON) -a message | sort -u; \
+	done
+
+clean:
+	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(BUILD)/%.html: $(BUILD)/%.form.json | $(CFHTML) $(BUILD)
 	$(CFHTML) --html5 --lists --title "$(TITLE)" --edition "$(EDITION)" < $< > $@
 
 $(BUILD)/%.form.json: %.md | $(JSON) $(CFCM) $(BUILD)
-	$(CFCM) parse --only form < $< | json content.0.form > $@
+	$(CFCM) parse --only form < $< | $(JSON) content.0.form > $@
 
 %.pdf: %.docx
 	unoconv $<

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -3,62 +3,60 @@
 
 This is the Open Use of Data Agreement, Version 0.1 (the "O-UDA").  Capitalized terms are defined in Section 5. Data Provider and you agree as follows.
 
-**Comment**: _The O-UDA is intended for use by a Data Provider that owns (or has sufficient rights from a data owner) to distribute data for unrestricted uses, subject to applicable laws governing the use of datasets of the type distributed. The O-UDA is not intended for a use of Data that may include personal data, or data not owned by a data provider. To be precise, it is not appropriate for data sets that include any data that might include materials subject to privacy laws such as the GDPR or HIPAA, or third party materials subject to copyright laws that have not been licensed for unrestricted use or dedicated to the public domain._
+<!-- The O-UDA is intended for use by a Data Provider that owns (or has sufficient rights from a data owner) to distribute data for unrestricted uses, subject to applicable laws governing the use of datasets of the type distributed. The O-UDA is not intended for a use of Data that may include personal data, or data not owned by a data provider. To be precise, it is not appropriate for data sets that include any data that might include materials subject to privacy laws such as the GDPR or HIPAA, or third party materials subject to copyright laws that have not been licensed for unrestricted use or dedicated to the public domain. -->
 
-1. **Provision of the Data**
+1.  **Provision of the Data**
 
-    1.1. You may use, modify, and distribute the Data made available to you by the Data Provider under this O-UDA if you follow the O-UDA's terms.
+    1.  You may use, modify, and distribute the Data made available to you by the Data Provider under this O-UDA if you follow the O-UDA's terms.
 
-      **Comment**: _The O-UDA permits very broad use of Data, and also modification and redistribution of the Data, so long as the recipient meets the O-UDA's requirements (and there are only a few of these). It is styled as a "permission to use" rather than a grant of specific rights, because the rights that may be applicable to any given database (whether copyright, database rights, or merely access rights) may vary around the world._
+        <!-- The O-UDA permits very broad use of Data, and also modification and redistribution of the Data, so long as the recipient meets the O-UDA's requirements (and there are only a few of these). It is styled as a "permission to use" rather than a grant of specific rights, because the rights that may be applicable to any given database (whether copyright, database rights, or merely access rights) may vary around the world. -->
 
-    1.2. Data Provider will not sue you or any Downstream Recipient for any claim arising out of the use, modification, or distribution of the Data provided you meet the terms of the O-UDA.
+    2.  Data Provider will not sue you or any Downstream Recipient for any claim arising out of the use, modification, or distribution of the Data provided you meet the terms of the O-UDA.
 
-      **Comment**: _This is a promise by the Data Provider not to sue the user so long as the user complies with O-UDA’s requirements. It doesn't allow a Data Provider to terminate a permitted use of the Data, but it does allow the Data Provider to bring an action to enforce the O-UDA’s terms._
+        <!-- This is a promise by the Data Provider not to sue the user so long as the user complies with O-UDA’s requirements. It doesn't allow a Data Provider to terminate a permitted use of the Data, but it does allow the Data Provider to bring an action to enforce the O-UDA’s terms. -->
 
+2.  **No Restrictions on Use or Output**
 
-2. **No Restrictions on Use or Output**
+    1.  The O-UDA does not impose any restriction with respect to:
 
-    2.1. The O-UDA does not impose any restriction with respect to:
+        1. the use or modification of Data; or
 
-      2.1.1. the use or modification of Data; or
+        2. the use, modification, or distribution of Outputs.
 
-      2.2.2. the use, modification, or distribution of Outputs.
+3.  **Redistribution of Data**
 
+    1.  You may redistribute the Data under terms of your choice, so long as:
 
-3. **Redistribution of Data**
+        1.  You include with any Data you redistribute all credit or attribution information that you received with the Data, and your terms require any Downstream Recipient to do the same; and
 
-    3.1. You may redistribute the Data under terms of your choice, so long as:
+        2.  Your terms include a warranty disclaimer and limitation of liability for Upstream Data Providers at least as broad as those contained in Section 4.2 and 4.3 of the O-UDA.
 
-      3.1.1. You include with any Data you redistribute all credit or attribution information that you received with the Data, and your terms require any Downstream Recipient to do the same; and
+        <!-- The only requirements for redistributing Data are to maintain attribution (if any) and use an agreement that contains Section 4’s disclaimers and limitations on liability, so that Downstream Recipients are bound by it for their use. These two restrictions apply only to the Data, but not to Output. Maintaining attribution is an accepted practice for sharing data to indicate its source or provenance. Requiring the use of disclaimers and liability limitations for subsequent distribution provides further certainty to a Data Provider. -->
 
-      3.1.2. Your terms include a warranty disclaimer and limitation of liability for Upstream Data Providers at least as broad as those contained in Section 4.2 and 4.3 of the O-UDA.
+4.  **No Warranty, Limitation of Liability**
 
-      **Comment**: _The only requirements for redistributing Data are to maintain attribution (if any) and use an agreement that contains Section 4’s disclaimers and limitations on liability, so that Downstream Recipients are bound by it for their use. These two restrictions apply only to the Data, but not to Output. Maintaining attribution is an accepted practice for sharing data to indicate its source or provenance. Requiring the use of disclaimers and liability limitations for subsequent distribution provides further certainty to a Data Provider._
+    1.  Data Provider does not represent or warrant that it has any rights whatsoever in the Data.
 
-4. **No Warranty, Limitation of Liability**
+        <!-- We have chosen a broad disclaimer of representations and warranties, which may not be appropriate in commercial contexts. These disclaimers are common in the open data context to encourage possessors of data to share the data without requiring them to make promises about the data. Because the Data Provider makes no claims that they have rights in the data, the Downstream Recipient must ensure that its use of the Data conforms to applicable laws or regulations. A Data Provider should not use the O-UDA for Data that it knows should not be distributed, or data that contains sensitive or private information. -->
 
-    4.1. Data Provider does not represent or warrant that it has any rights whatsoever in the Data.
+    2.  THE DATA IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
 
-      **Comment**: We have chosen a broad disclaimer of representations and warranties, which may not be appropriate in commercial contexts. These disclaimers are common in the open data context to encourage possessors of data to share the data without requiring them to make promises about the data. Because the Data Provider makes no claims that they have rights in the data, the Downstream Recipient must ensure that its use of the Data conforms to applicable laws or regulations. A Data Provider should not use the O-UDA for Data that it knows should not be distributed, or data that contains sensitive or private information._
+    3.  NEITHER DATA PROVIDER NOR ANY UPSTREAM DATA PROVIDER SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE DATA OR OUTPUTS, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-    4.2. THE DATA IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+    <!-- These disclaimers are necessary to limit Data Provider’s liability. They disclaim both express and implied warranties or representations, and the  disclaimer applies to all Upstream Data Providers. These limitations of liability are common in the open data context to encourage possessors of data to share the data without requiring them to accept liability to a user for downstream uses of the data, but may not be appropriate in commercial contexts. -->
 
-    4.3. NEITHER DATA PROVIDER NOR ANY UPSTREAM DATA PROVIDER SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE DATA OR OUTPUTS, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+5.  **Definitions**
 
-      **Comment**: _These disclaimers are necessary to limit Data Provider’s liability. They disclaim both express and implied warranties or representations, and the  disclaimer applies to all Upstream Data Providers. These limitations of liability are common in the open data context to encourage possessors of data to share the data without requiring them to accept liability to a user for downstream uses of the data, but may not be appropriate in commercial contexts._
+    1.  "Data" means the material you receive under the O-UDA in modified or unmodified form, but not including Output.
 
-5. **Definitions**
+        <!-- The term "Data" encompasses both the initial data made available to "you" as well as any later modifications made to that data by a Data Provider or a Downstream Recipient that redistributes the data. This also means that Downstream Recipients remain free to modify the data. Data specifically excludes Outputs. -->
 
-    5.1. "Data" means the material you receive under the O-UDA in modified or unmodified form, but not including Output.
+    2.  "Data Provider" means the source from which you receive the Data and with whom you enter into the O-UDA.
 
-      **Comment**: _The term "Data" encompasses both the initial data made available to "you" as well as any later modifications made to that data by a Data Provider or a Downstream Recipient that redistributes the data. This also means that Downstream Recipients remain free to modify the data. Data specifically excludes Outputs._
+    3.  "Downstream Recipient" means any person or persons who receives the Data directly or indirectly from you in accordance with the O-UDA.
 
-    5.2. "Data Provider" means the source from which you receive the Data and with whom you enter into the O-UDA.
+    4.  "Output" means the outcomes or results that you obtain from your use of Data that do not include more than a de minimis portion of the Data on which the use is based.  Output may include de minimis portions of the Data necessary to report on or explain use that has been conducted with the Data, such as figures in scientific papers, but do not include more.  Artificial intelligence models trained on Data (and which do not include more than a de minimis portion of Data) are Output.
 
-    5.3. "Downstream Recipient" means any person or persons who receives the Data directly or indirectly from you in accordance with the O-UDA.
+        <!-- The O-UDA defines “Output” to clarify that any AI model produced from the use of the Data (e.g., as a training set) should not typically be considered to be subject to the O-UDA's restrictions. The O-UDA considers that Outputs are not a "derivative" or a "modification" of the Data if they don't contain more than a de minimis portion of the Data. This is also intended to clarify that research papers and accompanying figures that may include only a de minimis part of the Data are not subject to any restriction in the O-UDA. -->
 
-    5.4. "Output" means the outcomes or results that you obtain from your use of Data that do not include more than a de minimis portion of the Data on which the use is based.  Output may include de minimis portions of the Data necessary to report on or explain use that has been conducted with the Data, such as figures in scientific papers, but do not include more.  Artificial intelligence models trained on Data (and which do not include more than a de minimis portion of Data) are Output.
-
-      **Comment**: _The O-UDA defines “Output” to clarify that any AI model produced from the use of the Data (e.g., as a training set) should not typically be considered to be subject to the O-UDA's restrictions. The O-UDA considers that Outputs are not a "derivative" or a "modification" of the Data if they don't contain more than a de minimis portion of the Data. This is also intended to clarify that research papers and accompanying figures that may include only a de minimis part of the Data are not subject to any restriction in the O-UDA._
-
-    5.5. "Upstream Data Providers" means the source or sources from which the Data Provider directly or indirectly received, under the terms of the O-UDA, material that is included in the Data.
+    5.  "Upstream Data Providers" means the source or sources from which the Data Provider directly or indirectly received, under the terms of the O-UDA, material that is included in the Data.

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -1,62 +1,51 @@
-# Open Use of Data Agreement v0.1
-# Annotated-Discussion-DRAFT-20190722
+# Open Use of Data Agreement v0.1 Annotated-Discussion-DRAFT-20190722
 
-This is the Open Use of Data Agreement, Version 0.1 (the "O-UDA").  Capitalized terms are defined in Section 5. Data Provider and you agree as follows.
+This is the Open Use of Data Agreement, Version 0.1 (the **O-UDA**).   Capitalized terms are defined in [Definitions](#definitions).   _Data Provider_ and you agree as follows.
 
-<!-- The O-UDA is intended for use by a Data Provider that owns (or has sufficient rights from a data owner) to distribute data for unrestricted uses, subject to applicable laws governing the use of datasets of the type distributed. The O-UDA is not intended for a use of Data that may include personal data, or data not owned by a data provider. To be precise, it is not appropriate for data sets that include any data that might include materials subject to privacy laws such as the GDPR or HIPAA, or third party materials subject to copyright laws that have not been licensed for unrestricted use or dedicated to the public domain. -->
+## Provision of the Data
 
-1.  **Provision of the Data**
+1.  You may use, modify, and distribute the _Data_ made available to you by the _Data Provider_ under this _O-UDA_ if you follow the _O-UDA_'s terms.
 
-    1.  You may use, modify, and distribute the Data made available to you by the Data Provider under this O-UDA if you follow the O-UDA's terms.
+2.  _Data Provider_ will not sue you or any _Downstream Recipient_ for any claim arising out of the use, modification, or distribution of the _Data_ provided you meet the terms of the _O-UDA_.
 
-        <!-- The O-UDA permits very broad use of Data, and also modification and redistribution of the Data, so long as the recipient meets the O-UDA's requirements (and there are only a few of these). It is styled as a "permission to use" rather than a grant of specific rights, because the rights that may be applicable to any given database (whether copyright, database rights, or merely access rights) may vary around the world. -->
+## No Restrictions on Use or _Output_
 
-    2.  Data Provider will not sue you or any Downstream Recipient for any claim arising out of the use, modification, or distribution of the Data provided you meet the terms of the O-UDA.
+The _O-UDA_ does not impose any restriction with respect to:
 
-        <!-- This is a promise by the Data Provider not to sue the user so long as the user complies with O-UDA’s requirements. It doesn't allow a Data Provider to terminate a permitted use of the Data, but it does allow the Data Provider to bring an action to enforce the O-UDA’s terms. -->
+1.  the use or modification of _Data_; or
 
-2.  **No Restrictions on Use or Output**
+2.  the use, modification, or distribution of _Outputs_.
 
-    1.  The O-UDA does not impose any restriction with respect to:
+## Redistribution of Data
 
-        1. the use or modification of Data; or
+You may redistribute the _Data_ under terms of your choice, so long as:
 
-        2. the use, modification, or distribution of Outputs.
+1.  You include with any _Data_ you redistribute all credit or attribution information that you received with the _Data_, and your terms require any _Downstream Recipient_ to do the same; and
 
-3.  **Redistribution of Data**
+2.  Your terms include a warranty disclaimer and limitation of liability for _Upstream Data Providers_ at least as broad as those contained in [General Disclaimer](#general-disclaimer) and [Limit on Liability](#limit-on-liabililty) of the _O-UDA_.
 
-    1.  You may redistribute the Data under terms of your choice, so long as:
+## No Warranty, Limitation of Liability
 
-        1.  You include with any Data you redistribute all credit or attribution information that you received with the Data, and your terms require any Downstream Recipient to do the same; and
+### No Warranty of Rights
 
-        2.  Your terms include a warranty disclaimer and limitation of liability for Upstream Data Providers at least as broad as those contained in Section 4.2 and 4.3 of the O-UDA.
+_Data Provider_ does not represent or warrant that it has any rights whatsoever in the _Data_.
 
-        <!-- The only requirements for redistributing Data are to maintain attribution (if any) and use an agreement that contains Section 4’s disclaimers and limitations on liability, so that Downstream Recipients are bound by it for their use. These two restrictions apply only to the Data, but not to Output. Maintaining attribution is an accepted practice for sharing data to indicate its source or provenance. Requiring the use of disclaimers and liability limitations for subsequent distribution provides further certainty to a Data Provider. -->
+### General Disclaimer
 
-4.  **No Warranty, Limitation of Liability**
+!!! The _Data_ is provided on an "as is" basis, without warranties or conditions of any kind, either express or implied including, without limitation, any warranties or conditions of title, non-infringement, merchantability or fitness for a particular purpose.
 
-    1.  Data Provider does not represent or warrant that it has any rights whatsoever in the Data.
+### Limit on Liability
 
-        <!-- We have chosen a broad disclaimer of representations and warranties, which may not be appropriate in commercial contexts. These disclaimers are common in the open data context to encourage possessors of data to share the data without requiring them to make promises about the data. Because the Data Provider makes no claims that they have rights in the data, the Downstream Recipient must ensure that its use of the Data conforms to applicable laws or regulations. A Data Provider should not use the O-UDA for Data that it knows should not be distributed, or data that contains sensitive or private information. -->
+!!! Neither _Data Provider_ nor any _Upstream Data Provider_ shall have any liability for any direct, indirect, incidental, special, exemplary, or consequential damages (including without limitation lost profits), however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the _Data_ or _Outputs_, even if advised of the possibility of such damages.
 
-    2.  THE DATA IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+## Definitions
 
-    3.  NEITHER DATA PROVIDER NOR ANY UPSTREAM DATA PROVIDER SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE DATA OR OUTPUTS, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+1.  **Data** means the material you receive under the _O-UDA_ in modified or unmodified form, but not including _Output_.
 
-    <!-- These disclaimers are necessary to limit Data Provider’s liability. They disclaim both express and implied warranties or representations, and the  disclaimer applies to all Upstream Data Providers. These limitations of liability are common in the open data context to encourage possessors of data to share the data without requiring them to accept liability to a user for downstream uses of the data, but may not be appropriate in commercial contexts. -->
+2.  **Data Provider** means the source from which you receive the _Data_ and with whom you enter into the _O-UDA_.
 
-5.  **Definitions**
+3.  **Downstream Recipient** means any person or persons who receives the _Data_ directly or indirectly from you in accordance with the _O-UDA_.
 
-    1.  "Data" means the material you receive under the O-UDA in modified or unmodified form, but not including Output.
+4.  **Output** means the outcomes or results that you obtain from your use of _Data_ that do not include more than a de minimis portion of the _Data_ on which the use is based.  _Output_ may include de minimis portions of the _Data_ necessary to report on or explain use that has been conducted with the _Data_, such as figures in scientific papers, but do not include more.  Artificial intelligence models trained on _Data_ (and which do not include more than a de minimis portion of _Data_) are _Output_.
 
-        <!-- The term "Data" encompasses both the initial data made available to "you" as well as any later modifications made to that data by a Data Provider or a Downstream Recipient that redistributes the data. This also means that Downstream Recipients remain free to modify the data. Data specifically excludes Outputs. -->
-
-    2.  "Data Provider" means the source from which you receive the Data and with whom you enter into the O-UDA.
-
-    3.  "Downstream Recipient" means any person or persons who receives the Data directly or indirectly from you in accordance with the O-UDA.
-
-    4.  "Output" means the outcomes or results that you obtain from your use of Data that do not include more than a de minimis portion of the Data on which the use is based.  Output may include de minimis portions of the Data necessary to report on or explain use that has been conducted with the Data, such as figures in scientific papers, but do not include more.  Artificial intelligence models trained on Data (and which do not include more than a de minimis portion of Data) are Output.
-
-        <!-- The O-UDA defines “Output” to clarify that any AI model produced from the use of the Data (e.g., as a training set) should not typically be considered to be subject to the O-UDA's restrictions. The O-UDA considers that Outputs are not a "derivative" or a "modification" of the Data if they don't contain more than a de minimis portion of the Data. This is also intended to clarify that research papers and accompanying figures that may include only a de minimis part of the Data are not subject to any restriction in the O-UDA. -->
-
-    5.  "Upstream Data Providers" means the source or sources from which the Data Provider directly or indirectly received, under the terms of the O-UDA, material that is included in the Data.
+5.  **Upstream Data Providers** means the source or sources from which the _Data Provider_ directly or indirectly received, under the terms of the _O-UDA_, material that is included in the _Data_.

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -36,7 +36,7 @@ _Data Provider_ does not represent or warrant that it has any rights whatsoever 
 
 ### Limit on Liability
 
-!!! Neither _Data Provider_ nor any _Upstream Data Provider_ shall have any liability for any direct, indirect, incidental, special, exemplary, or consequential damages (including without limitation lost profits), however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the _Data_ or _Output_, even if advised of the possibility of such damages.
+!!! Neither _Data Provider_ nor _Upstream Data Providers_ shall have any liability for any direct, indirect, incidental, special, exemplary, or consequential damages (including without limitation lost profits), however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the _Data_ or _Output_, even if advised of the possibility of such damages.
 
 ## Definitions
 

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -1,4 +1,4 @@
-# Open Use of Data Agreement v0.1 Annotated-Discussion-DRAFT-20190722
+# Open Use of Data Agreement
 
 This is the Open Use of Data Agreement, Version 0.1 (the **O-UDA**).   Capitalized terms are defined in [Definitions](#definitions).   _Data Provider_ and you agree as follows.
 

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -32,7 +32,7 @@ _Data Provider_ does not represent or warrant that it has any rights whatsoever 
 
 ### General Disclaimer
 
-!!! The _Data_ is provided on an "as is" basis, without warranties or conditions of any kind, either express or implied including, without limitation, any warranties or conditions of title, non-infringement, merchantability or fitness for a particular purpose.
+!!! The _Data_ are provided on an "as is" basis, without warranties or conditions of any kind, either express or implied including, without limitation, any warranties or conditions of title, non-infringement, merchantability or fitness for a particular purpose.
 
 ### Limit on Liability
 

--- a/O-UDA-0.1_annotated_discussion-draft.md
+++ b/O-UDA-0.1_annotated_discussion-draft.md
@@ -14,7 +14,7 @@ The _O-UDA_ does not impose any restriction with respect to:
 
 1.  the use or modification of _Data_; or
 
-2.  the use, modification, or distribution of _Outputs_.
+2.  the use, modification, or distribution of _Output_.
 
 ## Redistribution of Data
 
@@ -36,7 +36,7 @@ _Data Provider_ does not represent or warrant that it has any rights whatsoever 
 
 ### Limit on Liability
 
-!!! Neither _Data Provider_ nor any _Upstream Data Provider_ shall have any liability for any direct, indirect, incidental, special, exemplary, or consequential damages (including without limitation lost profits), however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the _Data_ or _Outputs_, even if advised of the possibility of such damages.
+!!! Neither _Data Provider_ nor any _Upstream Data Provider_ shall have any liability for any direct, indirect, incidental, special, exemplary, or consequential damages (including without limitation lost profits), however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the _Data_ or _Output_, even if advised of the possibility of such damages.
 
 ## Definitions
 

--- a/build-docs.ps1
+++ b/build-docs.ps1
@@ -1,2 +1,0 @@
-pandoc .\O-UDA-0.1_annotated_discussion-draft.md -o .\O-UDA-0.1_annotated_discussion-draft.docx
-pandoc .\O-UDA-0.1_annotated_discussion-draft.md -o .\O-UDA-0.1_annotated_discussion-draft.pdf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,829 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@kemitchell/docopt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@kemitchell/docopt/-/docopt-1.0.0.tgz",
+      "integrity": "sha512-j6LvUorsk1dV7GW1rqLhmIgc1kUnQ2EEiw3UJNBX+E+chCbzhqeuXSwnBZBzTq7rQNiAROUPacwHu+t2mHLP0g==",
+      "dev": true
+    },
+    "agreement-schedules-exhibits-numbering": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/agreement-schedules-exhibits-numbering/-/agreement-schedules-exhibits-numbering-2.0.0.tgz",
+      "integrity": "sha512-I1zT87H0nm4QTcv6yEegwdsKXZd+/pP8SdL5BgRV8IyzC4wfLO8TLEVoc1P4Ai68MZiCL3Tyw9VDI5MgnVZDAg==",
+      "dev": true,
+      "requires": {
+        "outline-numbering": "^2.0.0"
+      }
+    },
+    "alphabet-numbering": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/alphabet-numbering/-/alphabet-numbering-1.0.1.tgz",
+      "integrity": "sha1-ztNxNAEXEkaCC0EtTMwaiiQDFaw=",
+      "dev": true
+    },
+    "american-legal-archaisms": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/american-legal-archaisms/-/american-legal-archaisms-1.0.18.tgz",
+      "integrity": "sha512-hPV3mDDUdhi5GZ4CC8tfcw/ddjj6xXJyDoUP00LJKpjT4hGlqXiijl9iDQSptNCDBQa66xgZSPYFCIUii2U5gg==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "capitalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.0.tgz",
+      "integrity": "sha512-HwGrAbSn44Tm5Nz+m02oQHf+9y771rmb/cTbXFcoADy29LFRCj4PhWBT54qxfY2HJBWBplwx17Pd4ek6OFbr/Q==",
+      "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commonform-analyze": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-analyze/-/commonform-analyze-4.0.0.tgz",
+      "integrity": "sha512-6Ov9WR8OAg6ot8M/YTMtf2PCshP1HrhJYv7ddPs++xV0tvLxGdMQrJh+gKN+K0kZrq5kgRCRQ6OdAsPgZPHj4A==",
+      "dev": true,
+      "requires": {
+        "commonform-predicate": "^3.0.1"
+      }
+    },
+    "commonform-archaic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/commonform-archaic/-/commonform-archaic-2.0.1.tgz",
+      "integrity": "sha512-YXc2RuYyWq1qcssf43jcfT+NahMp0SRN3vvhwcl7Lo8LTnoVW18/uA3lPBY8vEwDTXZQcFma8M3JPnIQG0yzwg==",
+      "dev": true,
+      "requires": {
+        "american-legal-archaisms": "~1.0.4",
+        "commonform-phrase-annotator": "^2.0.0"
+      }
+    },
+    "commonform-commonmark": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commonform-commonmark/-/commonform-commonmark-4.1.1.tgz",
+      "integrity": "sha512-umCJISyj0IYENsR9c1kE5cPXCI8Gem3Vq7kViJKfR4ifxPA6G8w/hdGHO5vhbG0jhjsDtIpuGN3r03rpBUVesg==",
+      "dev": true,
+      "requires": {
+        "commonform-fix-strings": "^2.0.1",
+        "commonform-group-series": "^2.0.0",
+        "commonform-prepare-blanks": "^1.0.2",
+        "commonmark": "^0.29.0",
+        "emoji-regex": "^8.0.0",
+        "markdown-escape": "^1.0.0",
+        "nanoassert": "^2.0.0",
+        "simple-concat": "^1.0.0",
+        "yargs": "^13.2.4"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        }
+      }
+    },
+    "commonform-critique": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/commonform-critique/-/commonform-critique-1.0.2.tgz",
+      "integrity": "sha512-VUer3dBrUErgyxuFjpbABC2AODGm+/xvL8tkdHhwwt4UPULY0OT6N4pMFyMkKc5buspWFfXmL5TuRmeCd+dDaA==",
+      "dev": true,
+      "requires": {
+        "commonform-archaic": "^2.0.1",
+        "commonform-mscd": "^1.0.0",
+        "commonform-predicate": "^3.0.1",
+        "doubleplus-numbers": "^0.2.0",
+        "wordy-words": "^1.0.0"
+      }
+    },
+    "commonform-docx": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/commonform-docx/-/commonform-docx-5.0.2.tgz",
+      "integrity": "sha512-auAFRugejL8qSFV5QWkknhpJIrr2HAZH29hwqhSfLyY+vREFn5pMJBZ8rXzIIuMV+a9oTWD2o0ENW15RFP7yhg==",
+      "dev": true,
+      "requires": {
+        "@kemitchell/docopt": "^1.0.0",
+        "agreement-schedules-exhibits-numbering": "^2.0.0",
+        "commonform-flatten": "^1.0.0",
+        "commonform-hash": "^1.0.0",
+        "commonform-prepare-blanks": "^1.0.1",
+        "decimal-numbering": "^3.0.2",
+        "jszip": "^3.2.1",
+        "object-assign": "^4.1.1",
+        "ooxml-signature-pages": "^3.0.2",
+        "outline-numbering": "^2.0.0",
+        "plan-addenda-exhibits-numbering": "^3.0.0",
+        "resolutions-schedules-exhibits-numbering": "^1.0.0"
+      }
+    },
+    "commonform-fix-strings": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/commonform-fix-strings/-/commonform-fix-strings-2.0.1.tgz",
+      "integrity": "sha512-jlUOxSTeKak38/aySChIRcnBglihAMvsxp3erOTVJqkP79/VxQkN60PnucGmdFsdjGVp8w+b7rs80j/OZRA7Jw==",
+      "dev": true,
+      "requires": {
+        "commonform-predicate": "^3.0.1"
+      }
+    },
+    "commonform-flatten": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-flatten/-/commonform-flatten-1.0.0.tgz",
+      "integrity": "sha512-mUqPbdUnkesluUKIuejihbeuvbnvoQs99bjTTgPf7AJzLFLBhrM93wuMGOV/Vv2SaVmU1JQFeWCpLSI9kiCzog==",
+      "dev": true,
+      "requires": {
+        "commonform-resolve": "^2.0.0"
+      }
+    },
+    "commonform-group-series": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-group-series/-/commonform-group-series-2.0.0.tgz",
+      "integrity": "sha512-tSwjR8jmzltGBzUB+q8mNhPv3+34FAs+p6ChmfRxEYp61yyJAkKj4CX+TWs8dX+A6NISM2jgfxzHI34nhgl0IQ==",
+      "dev": true,
+      "requires": {
+        "commonform-predicate": "^3.0.0"
+      }
+    },
+    "commonform-hash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-hash/-/commonform-hash-1.0.0.tgz",
+      "integrity": "sha512-UWt+3e2neQLHy+mxT8MyiXyZtoGxPAz95wfuTOjD3uZ6RMs93Q5hoVw6OUSmTORFjGzEwsnAuo8X4XLB3urV5g==",
+      "dev": true,
+      "requires": {
+        "commonform-serialize": "^1.0.0",
+        "sha.js": "^2.4.5"
+      }
+    },
+    "commonform-html": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/commonform-html/-/commonform-html-3.1.5.tgz",
+      "integrity": "sha512-EviN/fPtPJIIgIk6RFDq884LjXkA/Jv4e+Yj7/DL2tA7H4U7o6oUDc0Tj9Vrc8kI7CNKHNIV600xyUyvbq2tWg==",
+      "dev": true,
+      "requires": {
+        "commonform-group-series": "^2.0.0",
+        "commonform-hash": "^1.0.0",
+        "commonform-predicate": "^3.0.1",
+        "commonform-prepare-blanks": "^1.0.1",
+        "escape-html": "^1.0.2",
+        "has": "^1.0.3",
+        "yargs": "^13.2.4"
+      }
+    },
+    "commonform-lint": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commonform-lint/-/commonform-lint-3.0.2.tgz",
+      "integrity": "sha512-l97tqGhIJhDgZtRVwDvH76u6a5QR7sGXkV37TM7NVsUe3zkVxeAHfXbrUnwOxxSmqvbdLcYVBuQGbAQqUjWKSA==",
+      "dev": true,
+      "requires": {
+        "commonform-analyze": "^4.0.0"
+      }
+    },
+    "commonform-mscd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-mscd/-/commonform-mscd-1.0.0.tgz",
+      "integrity": "sha512-7h5VTqaR+S9qXsp+6cIkaFz5apKWS4Iu2hI7rZU7ODUK0oYl94FuOa9+vpI37hCx7IWWVMknhjIE3tqhd7W/mw==",
+      "dev": true,
+      "requires": {
+        "commonform-regexp-annotator": "^2.0.0",
+        "escape-regexp": "0.0.1",
+        "mscd": "^0.1.0"
+      }
+    },
+    "commonform-number": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-number/-/commonform-number-1.0.0.tgz",
+      "integrity": "sha512-nwgW4D/cy87aj7yJApN1YxhiKUPgkSZva24PZTbVw+9bmheoRi0t5YwFU0w6aaoaSXC2eiLA9Yy0BgH9vWFFwg==",
+      "dev": true,
+      "requires": {
+        "commonform-group-series": "^2.0.0"
+      }
+    },
+    "commonform-phrase-annotator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-phrase-annotator/-/commonform-phrase-annotator-2.0.0.tgz",
+      "integrity": "sha512-JZO1QWcPlUXlYBZnFiirinIkaYCYBpJX+AKZ8ocXhwd/TLctzEwYA9cf3jN+ZX8PLve1BaHG6B6X48IQQ0XTEg==",
+      "dev": true,
+      "requires": {
+        "commonform-regexp-annotator": "^2.0.0",
+        "escape-regexp": "0.0.1"
+      }
+    },
+    "commonform-predicate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/commonform-predicate/-/commonform-predicate-3.0.1.tgz",
+      "integrity": "sha512-YzhrIRUTl0VitxlZM+fDmMepsinkaMHHuAsw0aUY9ang5nO79ymfib8fQqeG7mp7Bp5sJb15Spyi0qbvp8oMDw==",
+      "dev": true
+    },
+    "commonform-prepare-blanks": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/commonform-prepare-blanks/-/commonform-prepare-blanks-1.0.2.tgz",
+      "integrity": "sha512-AHXD85J5EX8lhe1EiuZhM5Kczqu86Ck5BOWai51Ksx8Is3q+nIH+xKidqgY/YEsUxeRa+Vn5B44cLtZYxTRM+Q==",
+      "dev": true
+    },
+    "commonform-regexp-annotator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-regexp-annotator/-/commonform-regexp-annotator-2.0.0.tgz",
+      "integrity": "sha512-NTLjPRIHyM21Rx/7h6xyP7TAZM/H4TybNMiZXDOXt/dlGr3F+dbND5nyPKA5iYzz8g0hZYbVeocikwuKqcRncQ==",
+      "dev": true,
+      "requires": {
+        "commonform-predicate": "^3.0.1"
+      }
+    },
+    "commonform-resolve": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/commonform-resolve/-/commonform-resolve-2.0.1.tgz",
+      "integrity": "sha512-VhFGVaMaTfZKcPnbc4QLUy0/wVTs9JATHwmSkYeheJc4/MXSDpL6oZ3sBxgOAukMFtkOZbvwzDpH6nnv+JVf/w==",
+      "dev": true,
+      "requires": {
+        "commonform-number": "^1.0.0",
+        "commonform-predicate": "^3.0.0",
+        "deep-equal": "^1.0.1"
+      }
+    },
+    "commonform-serialize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/commonform-serialize/-/commonform-serialize-1.0.0.tgz",
+      "integrity": "sha512-dlVKNxlxnCG+T4XJL8/skYuDVQpw+0hVRKkuFSJcZWEMRdTGHMQvSZtZE12Ksv83aVsgABEH1lgB2MGwLq/GPg==",
+      "dev": true,
+      "requires": {
+        "is-array": "^1.0.1",
+        "is-object": "^1.0.1"
+      }
+    },
+    "commonmark": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.0.tgz",
+      "integrity": "sha512-Wc3kvAIm0EK85pHsM95Fev31wEN6/zQpwd2qcLDL8psjHRoUFvUeGHevIJAdToWUuFoX8WI/gmeDauqy32xgJQ==",
+      "dev": true,
+      "requires": {
+        "entities": "~ 1.1.1",
+        "mdurl": "~ 1.0.1",
+        "minimist": "~ 1.2.0",
+        "string.prototype.repeat": "^0.2.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decimal-numbering": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/decimal-numbering/-/decimal-numbering-3.0.2.tgz",
+      "integrity": "sha512-MF3VlpRK2+7QyEeErR1ev7s+ZlL4+QsXk5sahiA/j6uv31EO0W6LJU0cCpqjzOykAxAfwgtEtQ7OJfjWxK45pw==",
+      "dev": true,
+      "requires": {
+        "lower-alpha": "^2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "doubleplus-numbers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/doubleplus-numbers/-/doubleplus-numbers-0.2.1.tgz",
+      "integrity": "sha1-LeYWZx9iPHaPhNSFalg74lIgXos=",
+      "dev": true,
+      "requires": {
+        "commonform-regexp-annotator": "^1.0.3"
+      },
+      "dependencies": {
+        "commonform-predicate": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/commonform-predicate/-/commonform-predicate-0.4.4.tgz",
+          "integrity": "sha1-3UH9J90UEwFJm2ccyLfH5RwQF/c=",
+          "dev": true
+        },
+        "commonform-regexp-annotator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/commonform-regexp-annotator/-/commonform-regexp-annotator-1.1.1.tgz",
+          "integrity": "sha1-/VrJvYSUFIp1lzGlQTOhtJ5l570=",
+          "dev": true,
+          "requires": {
+            "commonform-predicate": "^0.4.0"
+          }
+        }
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-regexp": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
+      "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ=",
+      "dev": true
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
+    "indefinite-article": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indefinite-article/-/indefinite-article-0.0.2.tgz",
+      "integrity": "sha1-S8hVJXBmz6th6mi+unXRANbiUGs=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+      "integrity": "sha1-6YUMwsyGDDvAl36EzPDdRkWEJ5o=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "json": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "dev": true
+    },
+    "jszip": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+      "dev": true,
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lower-alpha": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-alpha/-/lower-alpha-2.0.2.tgz",
+      "integrity": "sha1-ybIl+tVET7KKHy5/gmbMxyOlLek=",
+      "dev": true,
+      "requires": {
+        "alphabet-numbering": "^1.0.0"
+      }
+    },
+    "markdown-escape": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-1.0.2.tgz",
+      "integrity": "sha1-cYSuJFVMSehLgv1WSP4qU9H5Gwg=",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mscd": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/mscd/-/mscd-0.1.7.tgz",
+      "integrity": "sha512-jjdcvBCcBvAPxuexgGjEi0vlcdWNhsap9IuN7NVCI4IpmPQS/l5snnreXjHes0NUtFBwWjvm9I0+3t6q84ft8A==",
+      "dev": true
+    },
+    "mustache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==",
+      "dev": true
+    },
+    "nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "ooxml-signature-pages": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ooxml-signature-pages/-/ooxml-signature-pages-3.0.2.tgz",
+      "integrity": "sha512-1z9HVxpKVyk3m14nscrW2XQIn2TC9+7AVy8oBoMdlOmjuT7hMDjxUoaw80AGQ+VkUu9kJ1pRrLUMkmy92NTF6A==",
+      "dev": true,
+      "requires": {
+        "capitalize": "^2.0.0",
+        "indefinite-article": "0.0.2",
+        "string-repeat": "^1.1.1",
+        "xml-escape": "^1.0.0"
+      }
+    },
+    "outline-numbering": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/outline-numbering/-/outline-numbering-2.0.0.tgz",
+      "integrity": "sha512-n88+IJNHJwMZdLH9ukREt41fWkaFWuYBz8tqcv9F4s9JFwLMmpPWv34crqOKwQBAMHazuzBG2PI26F+/Jg5dBg==",
+      "dev": true,
+      "requires": {
+        "lower-alpha": "~2.0.0",
+        "romanize": "^1.1.1"
+      }
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "pako": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "plan-addenda-exhibits-numbering": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/plan-addenda-exhibits-numbering/-/plan-addenda-exhibits-numbering-3.0.0.tgz",
+      "integrity": "sha512-HBG3GLLhkoZ8Av4yQ2ML4U1XZ2IPGc7jGQaJK1rQ/RpciNTVloqdsph3b566s5sPYGQKM0hs+ELbC6t7Qn/Fvg==",
+      "dev": true,
+      "requires": {
+        "outline-numbering": "^2.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolutions-schedules-exhibits-numbering": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolutions-schedules-exhibits-numbering/-/resolutions-schedules-exhibits-numbering-1.0.0.tgz",
+      "integrity": "sha512-YFw5Teg3CgsqAr7G8JVPwXlAPEApIShFkXSjXzeAbMgrj+8TVpW9/x0YibfSdKb8BMEe6TS1EXAZRnwpRz8Rzg==",
+      "dev": true,
+      "requires": {
+        "agreement-schedules-exhibits-numbering": "^2.0.0"
+      }
+    },
+    "romanize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/romanize/-/romanize-1.1.1.tgz",
+      "integrity": "sha1-yVb6E4dkHINycDB3oAmc0bfXDBw=",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
+    "string-repeat": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-repeat/-/string-repeat-1.1.1.tgz",
+      "integrity": "sha1-4WINaezccXItpGMKayvEw4Gih3c=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      }
+    },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wordy-words": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordy-words/-/wordy-words-1.0.0.tgz",
+      "integrity": "sha512-yADoIf2iMVQyzzaZWlnP3RedZJzgg/9mhNx5tXinKNi4vYxyqePXpq78ZGUgZsyphL8fuNNWpyzaXINWpEn2ew==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      }
+    },
+    "xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "commonform-lint": "^3.0.2",
     "json": "^9.0.6",
     "mustache": "^3.0.1"
+  },
+  "scripts": {
+    "build": "make"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "commonform-commonmark": "^4.1.1",
+    "commonform-critique": "^1.0.2",
+    "commonform-docx": "^5.0.2",
+    "commonform-html": "^3.1.5",
+    "commonform-lint": "^3.0.2",
+    "json": "^9.0.6",
+    "mustache": "^3.0.1"
+  }
+}

--- a/styles.json
+++ b/styles.json
@@ -1,0 +1,12 @@
+{
+  "alignment": "left",
+  "heading": {
+    "italic": true
+  },
+  "reference": {
+    "italic": true
+  },
+  "referenceHeading": {
+    "italic": true
+  }
+}


### PR DESCRIPTION
This PR shows my work converting the current Markdown text to Common Form-compatible markup, as well as the structural fixes I was able to make thanks to Common Form tooling. I've also attached sample renderings in various formats.

A couple nits spotted:

1.  "Output" is defined in the singular, covers all output, but used twice in the plural.

2.  Subject-verb number agreement error in the general warranty disclaimer.

    >  The _Data_ <del>is</del><ins>are</ins> provided on an "as is" basis ...

Personally, I'd also pick either singular "Upstream Data Provider" singular or "Upstream Data Providers" plural and use throughout.

Time permitting, I do plan to make substantive comments. But I start with getting this kind of text over into workable formats if I can, and thought I might as well share.

For what it's worth, I do expect using this more idiomatic approach to typing up in Markdown could get you more PRs. That's been my experience with other legal terms on GitHub.